### PR TITLE
fix: CheckAgentOffShip takes no parameters in NavalDLC v1.4.5

### DIFF
--- a/source/RTSCamera/src/Patch/Naval/Patch_AgentNavalComponent.cs
+++ b/source/RTSCamera/src/Patch/Naval/Patch_AgentNavalComponent.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using MissionSharedLibrary.Utilities;
 using System;
 using System.Reflection;
@@ -54,8 +54,9 @@ namespace RTSCamera.Patch.Naval
                 return true;
             }
 
-             ____lastOffShipCheckTime += 5f;
-            _checkAgentOffShip.Invoke(__instance, new object[] { false });
+            ____lastOffShipCheckTime += 5f;
+            // v1.4.5: CheckAgentOffShip() is now parameterless — bool argument was removed
+            _checkAgentOffShip.Invoke(__instance, null);
             return true;
         }
     }


### PR DESCRIPTION
## Problem

In Bannerlord v1.4.5 (NavalDLC update), `AgentNavalComponent.CheckAgentOffShip()` was changed to a **parameterless** method. RTSCamera's `Patch_AgentNavalComponent.Prefix_OnTick` still invokes it with `new object[] { false }`, causing:

```
System.Reflection.TargetParameterCountException: Parameter count mismatch
```

This crashes any naval mission (WarSails DLC) as soon as the scene loads.

## Root Cause

Confirmed by inspecting `NavalDLC.dll` v1.4.5 metadata — `CheckAgentOffShip` has **0 parameters** in v1.4.5 vs the previous `bool` parameter in v1.3.x.

## Fix

Pass `null` instead of `new object[] { false }` to `MethodInfo.Invoke`, which is the correct way to call a parameterless method via reflection.

```csharp
// Before (crashes v1.4.5):
_checkAgentOffShip.Invoke(__instance, new object[] { false });

// After:
_checkAgentOffShip.Invoke(__instance, null);
```

## Testing

- Bannerlord v1.4.5
- NavalDLC installed
- WarSails campaign mission loads and plays without crash