### PR TITLE
Fix NavalDLC v1.4.5 compatibility and null-safety in naval missions

### DIFF
--- a/source/RTSCamera.CommandSystem/RTSCamera.CommandSystem.csproj
+++ b/source/RTSCamera.CommandSystem/RTSCamera.CommandSystem.csproj
@@ -135,7 +135,7 @@
     </Reference>
   </ItemGroup>
 
-  <Target Name="RemoveModulePackageDir" AfterTargets="BeforeBuild">
+  <Target Name="RemoveModulePackageDir" AfterTargets="BeforeBuild" Condition="'$(OS)'=='Windows_NT'">
     <Exec Command="rmdir &quot;$(ModulePackagePath)&quot; /s /q" />
   </Target>
 
@@ -149,7 +149,7 @@
     <Copy SourceFiles="@(_HarmonyAssemblies)" DestinationFolder="$(TargetDir)" SkipUnchangedFiles="true" />
   </Target>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(OS)'=='Windows_NT'">
     <Exec Command="xcopy &quot;$(TargetPath)&quot; &quot;$(ModulePackagePath)bin\Win64_Shipping_Client\&quot; /C /I /Y /F" />
     <Exec Command="xcopy &quot;$(TargetDir)MissionLibrary.dll&quot; &quot;$(ModulePackagePath)bin\Win64_Shipping_Client\&quot; /C /I /Y /F" />
     <Exec Command="xcopy &quot;$(TargetDir)RTSCameraAgentComponent.dll&quot; &quot;$(ModulePackagePath)bin\Win64_Shipping_Client\&quot; /C /I /Y /F" />
@@ -161,7 +161,7 @@
     <Exec Command="xcopy &quot;$(ProjectDir)Modules\.&quot; &quot;$(PackagePath)&quot; /E /C /I /Y /F&#xD;&#xA;" />
 
   </Target>
-  <Target Name="DeployModFiles" AfterTargets="PostBuild" Condition="'$(TargetFramework)' == 'net472'">
+  <Target Name="DeployModFiles" AfterTargets="PostBuild" Condition="'$(TargetFramework)' == 'net472' And '$(OS)'=='Windows_NT'">
     <Exec Command="xcopy &quot;$(ModulePackagePath).&quot; &quot;$(GamePath)Modules\$(ModuleAlias)&quot; /E /C /I /Y /F" />
   </Target>
 

--- a/source/RTSCamera.CommandSystem/src/AgentComponents/CommandSystemAgentComponent.cs
+++ b/source/RTSCamera.CommandSystem/src/AgentComponents/CommandSystemAgentComponent.cs
@@ -78,15 +78,25 @@ namespace RTSCamera.CommandSystem.AgentComponents
             }
 
             _mesh = MetaMesh.GetCopy("rts_unit_marker");
+            if (_mesh == null)
+                return;
             if (_material == null)
             {
-                _material = _mesh.GetMeshAtIndex(0).GetMaterial().CreateCopy();
+                var baseMesh = _mesh.GetMeshAtIndex(0);
+                if (baseMesh == null)
+                    return;
+                _material = baseMesh.GetMaterial()?.CreateCopy();
+                if (_material == null)
+                    return;
                 _material.Flags |= MaterialFlags.TwoSided;
             }
             _mesh.SetMaterial(_material);
             //ClearMaterial();
             UpdateMeshFrame(Agent.HasMount);
-            Agent.AgentVisuals.GetEntity().AddMultiMesh(_mesh);
+            var entity = Agent.AgentVisuals?.GetEntity();
+            if (entity == null)
+                return;
+            entity.AddMultiMesh(_mesh);
             _mesh.SetFactor1(InvisibleColor);
             _mesh.SetContourColor(InvisibleColor);
             _mesh.SetContourState(false);

--- a/source/RTSCamera/RTSCamera.csproj
+++ b/source/RTSCamera/RTSCamera.csproj
@@ -141,7 +141,7 @@
     </Reference>
   </ItemGroup>
 
-  <Target Name="RemoveModulePackageDir" AfterTargets="BeforeBuild">
+  <Target Name="RemoveModulePackageDir" AfterTargets="BeforeBuild" Condition="'$(OS)'=='Windows_NT'">
     <Exec Command="rmdir &quot;$(ModulePackagePath)&quot; /s /q" />
   </Target>
   
@@ -155,7 +155,7 @@
     <Copy SourceFiles="@(_HarmonyAssemblies)" DestinationFolder="$(TargetDir)" SkipUnchangedFiles="true" />
   </Target> 
   
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(OS)'=='Windows_NT'">
     <Exec Command="xcopy &quot;$(TargetPath)&quot; &quot;$(ModulePackagePath)bin\Win64_Shipping_Client\&quot; /C /I /Y /F" />
     <Exec Command="xcopy &quot;$(TargetDir)MissionLibrary.dll&quot; &quot;$(ModulePackagePath)bin\Win64_Shipping_Client\&quot; /C /I /Y /F" />
     <Exec Command="xcopy &quot;$(TargetDir)RTSCameraAgentComponent.dll&quot; &quot;$(ModulePackagePath)bin\Win64_Shipping_Client\&quot; /C /I /Y /F" />
@@ -167,7 +167,7 @@
     <Exec Command="xcopy &quot;$(ProjectDir)Modules\.&quot; &quot;$(PackagePath)&quot; /E /C /I /Y /F" />
   </Target>
 
-  <Target Name="DeployModFiles" AfterTargets="PostBuild" Condition="'$(TargetFramework)' == 'net472'">
+  <Target Name="DeployModFiles" AfterTargets="PostBuild" Condition="'$(TargetFramework)' == 'net472' And '$(OS)'=='Windows_NT'">
     <Exec Command="xcopy &quot;$(ModulePackagePath).&quot; &quot;$(GamePath)Modules\$(ModuleAlias)&quot; /E /C /I /Y /F" />
   </Target>
 </Project>

--- a/source/RTSCamera/src/Patch/Naval/Patch_AgentNavalComponent.cs
+++ b/source/RTSCamera/src/Patch/Naval/Patch_AgentNavalComponent.cs
@@ -55,7 +55,7 @@ namespace RTSCamera.Patch.Naval
             }
 
              ____lastOffShipCheckTime += 5f;
-            _checkAgentOffShip.Invoke(__instance, new object[] { false });
+            _checkAgentOffShip.Invoke(__instance, Array.Empty<object>());
             return true;
         }
     }


### PR DESCRIPTION
## Summary

- **`Patch_AgentNavalComponent`**: `AgentNavalComponent.CheckAgentOffShip()` had its `bool` parameter removed in NavalDLC v1.4.5. The Harmony prefix was still invoking it via reflection with `new object[] { false }`, causing a `TargetParameterCountException` on every naval battle tick — this is what produced the \"RTS Camera: Patch failed\" startup warning. Fixed by passing `Array.Empty<object>()` instead.

- **`CommandSystemAgentComponent.InitializeAux`**: Added null guards for `MetaMesh.GetCopy("rts_unit_marker")`, `GetMeshAtIndex(0)`, `GetMaterial()`, and `Agent.AgentVisuals?.GetEntity()`. Naval agents on ships can have null visuals, causing a `NullReferenceException` that surfaced during formation colour updates (`FormationColorSubLogicV2.OnPreDisplayMissionTick`).

- **`RTSCamera.csproj`, `RTSCamera.CommandSystem.csproj`**: Added `Condition="'$(OS)'=='Windows_NT'"` to the `rmdir`/`xcopy` build targets (`RemoveModulePackageDir`, `PostBuild`, `DeployModFiles`) so the projects build cleanly on Linux/WSL.

## Test plan

- [ ] Start a naval battle — confirm \"RTS Camera: Patch failed\" no longer appears in the startup HUD
- [ ] Play through a naval battle without `NullReferenceException` spam from `CommandSystemAgentComponent`
- [ ] Verify formation highlighting (contour colours) works correctly during naval combat
- [ ] Build on Linux/WSL with `dotnet build -f net472` — should complete without `rmdir`/`xcopy` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)